### PR TITLE
remove stale entries from recently_departed list when market closes

### DIFF
--- a/lloidbot.py
+++ b/lloidbot.py
@@ -151,8 +151,8 @@ class Lloid(discord.Client):
                         del self.associated_message[message.author.id]
                 elif command.cmd == Command.Done:
                     guest = message.author.id
-                    if guest in self.recently_departed:
-                        owner = self.recently_departed[guest]
+                    owner = self.recently_departed.pop(guest, None)
+                    if owner is not None:
                         self.sleepers[owner].cancel()
                         await message.channel.send("Thanks for the heads-up! Letting the next person in now.")
                 else:


### PR DESCRIPTION
Did the most straightforward thing (unless you plan to use recently_departed for something down the line)