### PR TITLE
Add sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Running:
      - TOKEN: The bot's token, which can be found [here](https://discordapp.com/developers/applications)
      - ANNOUNCE_ID: The ID of the channel to post price announcements in. These can by obtained by right-clicking the channel and selecting "Copy ID"
      - QUEUE_INTERVAL: The amount of seconds it takes for one position in the queue to resolve. If not set, it will default to 600 seconds.
+     - SENTRY_DSN: The DSN used to connect with Sentry for error reporting.
 5. Run lloidbot.py
 
 Tweaking:

--- a/lloidbot.py
+++ b/lloidbot.py
@@ -7,6 +7,7 @@ import sys
 from dotenv import load_dotenv
 import os
 import re
+import sentry_sdk
 
 queue = []
 queue_interval = 60*10
@@ -328,12 +329,17 @@ if __name__ == "__main__":
     load_dotenv()
     token = os.getenv("TOKEN")
     interval = os.getenv("QUEUE_INTERVAL")
+    sentry_dsn = os.getenv("SENTRY_DSN")
 
     if not token:
         raise Exception('TOKEN env variable is not defined')
 
     if not os.getenv("ANNOUNCE_ID"):
         raise Exception('ANNOUNCE_ID env variable is not defined')
+
+    if sentry_dsn:
+        sentry_sdk.init(sentry_dsn)
+        print("Connected to Sentry")
 
     if interval:
         queue_interval = int(interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py
 python-dotenv
+sentry_sdk
+freezegun


### PR DESCRIPTION
It's entirely optional in its usage, but it should help tracking some errors being thrown.

It'll send emails when things go wrong, as well as a fairly detailed overview whenever something breaks:

![image](https://user-images.githubusercontent.com/4731930/78818741-6c49eb00-79d5-11ea-9935-c10a9c123119.png)
